### PR TITLE
Add BottomAreaAvoider: factor out from KeyboardAvoider

### DIFF
--- a/lib/bottom_area_avoider.dart
+++ b/lib/bottom_area_avoider.dart
@@ -1,0 +1,191 @@
+import 'dart:collection';
+import 'package:flutter/widgets.dart';
+import 'package:flutter/rendering.dart';
+
+/// Helps [child] stay visible by resizing it to avoid the given [areaToAvoid].
+///
+/// Wraps the [child] in a [AnimatedContainer] that adjusts its bottom [padding] to accommodate the given area.
+///
+/// If [autoScroll] is true and the [child] contains a focused widget such as a [TextField],
+/// automatically scrolls so that it is just visible above the keyboard, plus any additional [overscroll].
+class BottomAreaAvoider extends StatefulWidget {
+
+  static const Duration defaultDuration = Duration(milliseconds: 100);
+  static const Curve defaultCurve = Curves.easeIn;
+  static const double defaultOverscroll = 12.0;
+  static const bool defaultAutoScroll = false;
+
+  /// The child to embed.
+  ///
+  /// If the [child] is not a [ScrollView], it is automatically embedded in a [SingleChildScrollView].
+  /// If the [child] is a [ScrollView], it must have a [ScrollController].
+  final Widget child;
+
+  /// Amount of bottom area to avoid. For example, the height of the currently-showing system keyboard, or
+  /// any custom bottom overlays.
+  final double areaToAvoid;
+
+  /// Whether to auto-scroll to the focused widget after the keyboard appears. Defaults to false.
+  /// Could be expensive because it searches all the child objects in this widget's render tree.
+  final bool autoScroll;
+
+  /// Extra amount to scroll past the focused widget. Defaults to [defaultOverscroll].
+  /// Useful in case the focused widget is inside a parent widget that you also want to be visible.
+  final double overscroll;
+
+  /// Duration of the resize animation. Defaults to [defaultDuration]. To disable, set to [Duration.zero].
+  final Duration duration;
+
+  /// Animation curve. Defaults to [defaultCurve]
+  final Curve curve;
+
+  BottomAreaAvoider({
+    Key key,
+    @required this.child,
+    @required this.areaToAvoid,
+    this.autoScroll = false,
+    this.duration = defaultDuration,
+    this.curve = defaultCurve,
+    this.overscroll = defaultOverscroll,
+  })  : assert(child is ScrollView ? child.controller != null : true),
+        super(key: key);
+
+  BottomAreaAvoiderState createState() => BottomAreaAvoiderState();
+}
+
+class BottomAreaAvoiderState extends State<BottomAreaAvoider> {
+  final _animationKey = new GlobalKey<ImplicitlyAnimatedWidgetState>();
+  Function(AnimationStatus) _animationListener;
+  ScrollController _scrollController;
+  double _previousAreaToAvoid;
+
+  @override
+  void didUpdateWidget(BottomAreaAvoider oldWidget) {
+    _previousAreaToAvoid = oldWidget.areaToAvoid;
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
+  void dispose() {
+    _animationKey.currentState?.animation?.removeStatusListener(_animationListener);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Add a status listener to the animation after the initial build.
+    // Wait a frame so that _animationKey.currentState is not null.
+    if (_animationListener == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _animationListener = _paddingAnimationStatusChanged;
+        _animationKey.currentState.animation.addStatusListener(_animationListener);
+      });
+    }
+
+    // If [child] is a [ScrollView], get its [ScrollController]
+    // and embed the [child] directly in an [AnimatedContainer].
+    if (widget.child is ScrollView) {
+      var scrollView = widget.child as ScrollView;
+      _scrollController = scrollView.controller;
+      return _buildAnimatedContainer(widget.child);
+    }
+    // If [child] is not a [ScrollView], and [autoScroll] is true,
+    // embed the [child] in a [SingleChildScrollView] to make
+    // it possible to scroll to the focused widget.
+    if (widget.autoScroll) {
+      _scrollController = new ScrollController();
+      return _buildAnimatedContainer(LayoutBuilder(
+        builder: (context, constraints) {
+          return SingleChildScrollView(
+            controller: _scrollController,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                minHeight: constraints.maxHeight,
+              ),
+              child: widget.child,
+            ),
+          );
+        },
+      ));
+    }
+    // Just embed the [child] directly in an [AnimatedContainer].
+    return _buildAnimatedContainer(widget.child);
+  }
+
+  Widget _buildAnimatedContainer(Widget child) {
+    debugPrint('buildAnimatedContainer w ${widget.areaToAvoid}');
+    return AnimatedContainer(
+      key: _animationKey,
+      padding: EdgeInsets.only(bottom: widget.areaToAvoid),
+      duration: widget.duration,
+      curve: widget.curve,
+      child: child,
+    );
+  }
+
+  /// Called whenever the status of our padding animation changes.
+  ///
+  /// If the animation has completed, we added overlap, and scroll is on, scroll to that.
+  void _paddingAnimationStatusChanged(AnimationStatus status) {
+    if (status != AnimationStatus.completed) {
+      return; // Only check when the animation is finishing
+    }
+    if (!widget.autoScroll) {
+      return; // auto scroll is not enabled, do nothing
+    }
+    if (widget.areaToAvoid <= _previousAreaToAvoid) {
+      return; // decreased-- do nothing. We only scroll when area to avoid is added (keyboard shown).
+    }
+
+    // Need to wait a frame to get the new size (todo: is this still needed? we dont use mediaquery anymore)
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (context == null || !mounted) {
+        return; // context is no longer valid
+      }
+      final focused = findFocusedObject(context.findRenderObject());
+      if (focused == null) {
+        return; // no focused object found
+      }
+      scrollToObject(focused, _scrollController, widget.duration, widget.curve, widget.overscroll);
+    });
+  }
+}
+
+/// Utility helper methods
+
+/// Finds the first focused focused child of [root] using a breadth-first search.
+RenderObject findFocusedObject(RenderObject root) {
+  final q = Queue<RenderObject>();
+  q.add(root);
+  while (q.isNotEmpty) {
+    final node = q.removeFirst();
+    final config = SemanticsConfiguration();
+    node.describeSemanticsConfiguration(config);
+    if (config.isFocused) {
+      return node;
+    }
+    node.visitChildrenForSemantics((child) {
+      q.add(child);
+    });
+  }
+  return null;
+}
+
+/// Scroll to the given [object], which must be inside [scrollController]s viewport.
+scrollToObject(RenderObject object, ScrollController scrollController, Duration duration, Curve curve, 
+    double overscroll) {
+  // Calculate the offset needed to show the object in the [ScrollView]
+  // so that its bottom touches the top of the keyboard.
+  final viewport = RenderAbstractViewport.of(object);
+  final offset = viewport.getOffsetToReveal(object, 1.0).offset + overscroll;
+
+  // If the object is covered by the keyboard, scroll to reveal it,
+  // and add [focusPadding] between it and top of the keyboard.
+  if (offset > scrollController.position.pixels) {
+    scrollController.position.moveTo(
+      offset,
+      duration: duration,
+      curve: curve,
+    );
+  }
+}

--- a/lib/keyboard_avoider.dart
+++ b/lib/keyboard_avoider.dart
@@ -1,38 +1,38 @@
 import 'dart:math';
-import 'dart:collection';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';
 
-/// Wraps the [child] in a [AnimatedContainer] that adjusts its bottom [padding] to accommodate the on-screen keyboard.
+import 'bottom_area_avoider.dart';
+
+/// A widget that re-sizes its [child] to avoid the system keyboard.
+///
 /// Unlike a [Scaffold], it only insets by the actual amount obscured by the keyboard.
-/// If [autoScroll] is true and the [child] contains a focused widget such as a [TextField],
-/// automatically scrolls so that it is just visible above the keyboard, plus any additional [focusPadding].
+///
+/// Watches for media query changes via [didChangeMetrics], and adjusts a [BottomAreaAvoider] accordingly.
 class KeyboardAvoider extends StatefulWidget {
-  /// The child to embed. If the [child] is not a [ScrollView], it is automatically embedded in a [SingleChildScrollView].
-  /// If the [child] is a [ScrollView], it must have a [ScrollController].
+
+  /// See [BottomAreaAvoider.child]
   final Widget child;
 
-  /// Duration of the resize animation. Defaults to 100ms. To disable, set to [Duration.zero].
+  /// See [BottomAreaAvoider.duration]
   final Duration duration;
 
-  /// Animation curve. Defaults to [easeOut]
+  /// See [BottomAreaAvoider.curve]
   final Curve curve;
 
-  /// Whether to auto-scroll to the focused widget after the keyboard appears. Defaults to false.
-  /// Could be expensive because it searches all the child objects in this widget's render tree.
+  /// See [BottomAreaAvoider.autoScroll]
   final bool autoScroll;
 
-  /// Space to put between the focused widget and the top of the keyboard. Defaults to 12.
-  /// Useful in case the focused widget is inside a parent widget that you also want to be visible.
-  final double focusPadding;
+  /// See [BottomAreaAvoider.overscroll]
+  final double overscroll;
 
   KeyboardAvoider({
     Key key,
     @required this.child,
-    this.duration = const Duration(milliseconds: 100),
-    this.curve = Curves.easeOut,
-    this.autoScroll = false,
-    this.focusPadding = 12.0,
+    this.duration = BottomAreaAvoider.defaultDuration,
+    this.curve = BottomAreaAvoider.defaultCurve,
+    this.autoScroll = BottomAreaAvoider.defaultAutoScroll,
+    this.overscroll = BottomAreaAvoider.defaultOverscroll,
   })  : assert(child is ScrollView ? child.controller != null : true),
         super(key: key);
 
@@ -40,10 +40,9 @@ class KeyboardAvoider extends StatefulWidget {
 }
 
 class _KeyboardAvoiderState extends State<KeyboardAvoider> with WidgetsBindingObserver {
-  final _animationKey = new GlobalKey<ImplicitlyAnimatedWidgetState>();
-  Function(AnimationStatus) _animationListener;
-  ScrollController _scrollController;
-  double _overlap = 0.0;
+  
+  /// The current amount of keyboard overlap.
+  double _keyboardOverlap = 0.0;
 
   @override
   void initState() {
@@ -54,88 +53,34 @@ class _KeyboardAvoiderState extends State<KeyboardAvoider> with WidgetsBindingOb
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    _animationKey.currentState?.animation?.removeStatusListener(_animationListener);
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    // Add a status listener to the animation after the initial build.
-    // Wait a frame so that _animationKey.currentState is not null.
-    if (_animationListener == null) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        _animationListener = _animationStatusChanged;
-        _animationKey.currentState.animation.addStatusListener(_animationListener);
-      });
-    }
-
-    // If [child] is a [ScrollView], get its [ScrollController]
-    // and embed the [child] directly in an [AnimatedContainer].
-    if (widget.child is ScrollView) {
-      var scrollView = widget.child as ScrollView;
-      _scrollController = scrollView.controller;
-      return _buildAnimatedContainer(widget.child);
-    }
-
-    // If [child] is not a [ScrollView], and [autoScroll] is true,
-    // embed the [child] in a [SingleChildScrollView] to make
-    // it possible to scroll to the focused widget.
-    if (widget.autoScroll) {
-      _scrollController = new ScrollController();
-      return _buildAnimatedContainer(LayoutBuilder(
-        builder: (context, constraints) {
-          return SingleChildScrollView(
-            controller: _scrollController,
-            child: ConstrainedBox(
-              constraints: BoxConstraints(
-                minHeight: constraints.maxHeight,
-              ),
-              child: widget.child,
-            ),
-          );
-        },
-      ));
-    }
-
-    // Just embed the [child] directly in an [AnimatedContainer].
-    return _buildAnimatedContainer(widget.child);
+    return BottomAreaAvoider(
+      child: widget.child,
+      areaToAvoid: _keyboardOverlap,
+      autoScroll: widget.autoScroll,
+      curve: widget.curve,
+      duration: widget.duration,
+      overscroll: widget.overscroll,
+    );
   }
 
   /// WidgetsBindingObserver
 
   @override
   void didChangeMetrics() {
-    //Need to wait a frame to get the new size
+    // Need to wait a frame to get the new size
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _resize();
     });
   }
 
-  /// AnimationStatus
-
-  void _animationStatusChanged(AnimationStatus status) {
-    if (status == AnimationStatus.completed) {
-      final keyboardVisible = MediaQuery.of(context).viewInsets.bottom > 0.0;
-      if (keyboardVisible) {
-        _keyboardShown();
-      }
-    }
-  }
-
-  /// Private
-
-  Widget _buildAnimatedContainer(Widget child) {
-    return AnimatedContainer(
-      key: _animationKey,
-      padding: EdgeInsets.only(bottom: _overlap),
-      duration: widget.duration,
-      curve: widget.curve,
-      child: child,
-    );
-  }
-
+  /// Re-calculates the amount of overlap, based on the current [MediaQueryData.viewInsets].
   void _resize() {
-    if (context == null) {
+    if (context == null || !mounted) {
       return;
     }
 
@@ -163,67 +108,10 @@ class _KeyboardAvoiderState extends State<KeyboardAvoider> with WidgetsBindingOb
 
     // If widget is partially obscured by the keyboard, adjust bottom padding to fully expose it
     final overlap = max(0.0, widgetRect.bottom - keyboardTop);
-    if (overlap != _overlap) {
+    if (overlap != _keyboardOverlap) {
       setState(() {
-        _overlap = overlap;
+        _keyboardOverlap = overlap;
       });
-    }
-  }
-
-  void _keyboardShown() {
-    // If auto scroll is not enabled, do nothing
-    if (!widget.autoScroll) {
-      return;
-    }
-    // Need to wait a frame to get the new size
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _scrollToFocusedObject();
-    });
-  }
-
-  void _scrollToFocusedObject() {
-    if (context == null) {
-      return;
-    }
-
-    final focused = _findFocusedObject(context.findRenderObject());
-    if (focused != null) {
-      _scrollToObject(focused);
-    }
-  }
-
-  /// Finds the first focused [RenderEditable] child of [root] using a breadth-first search.
-  RenderObject _findFocusedObject(RenderObject root) {
-    final q = Queue<RenderObject>();
-    q.add(root);
-    while (q.isNotEmpty) {
-      final node = q.removeFirst();
-      if (node is RenderEditable && node.hasFocus) {
-        return node;
-      }
-      node.visitChildren((child) {
-        q.add(child);
-      });
-    }
-    return null;
-  }
-
-  /// If the focused object is covered by the keyboard, scroll to it.
-  /// Otherwise do nothing.
-  _scrollToObject(RenderObject object) {
-    // Calculate the offset needed to show the object in the [ScrollView]
-    // so that its bottom touches the top of the keyboard.
-    final viewport = RenderAbstractViewport.of(object);
-    final offset = viewport.getOffsetToReveal(object, 1.0).offset + widget.focusPadding;
-
-    // If the object is covered by the keyboard, scroll to reveal it,
-    // and add [focusPadding] between it and top of the keyboard.
-    if (offset > _scrollController.position.pixels) {
-      _scrollController.position.moveTo(
-        offset,
-        duration: widget.duration,
-        curve: widget.curve,
-      );
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.2.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -45,7 +45,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.3+1"
+    version: "0.12.5"
   meta:
     dependency: transitive
     description:
@@ -60,13 +60,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.2"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.0"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -78,7 +85,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "1.5.5"
   stack_trace:
     dependency: transitive
     description:
@@ -92,7 +99,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.8"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
@@ -106,14 +113,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.5"
   typed_data:
     dependency: transitive
     description:
@@ -129,4 +136,4 @@ packages:
     source: hosted
     version: "2.0.8"
 sdks:
-  dart: ">=2.0.0 <3.0.0"
+  dart: ">=2.2.0 <3.0.0"


### PR DESCRIPTION
Hi! First thanks for the great library and article :D

I started using it in `flutter_keyboard_actions`, a little library to float a keyboard actions bar over the system keyboard:

Spinning off from that I thought I could add support here for a couple of my use cases:
* Avoid any bottom content, not just the system keyboard- for example, an additional action bar floating on top of the system keyboard. Or, avoid a custom keyboard.
* Autoscroll to focus nodes that aren't backed by RenderEditables, like a focused 'submit' button while using an accessibility keyboard.

Changes: 
* Factor out BottomAreaAvoider, and build KeyboardAvoider ontop of it. BottomAreaAvoider is a more generic widget that avoids any given set value. This allows making an avoider thats not necessarily based on the system keyboard.  I have a use case for a page that uses my own custom keyboard, which I'd still like to avoid!
* Make `scrollToObject` and `findFocusedObject` static utility methods for easy re-use
* Consolidate scrolling logic into `_paddingAnimationStatusChanged`
* Change `findFocusedObject` implementation: find focused nodes based on their  SemanticsConfiguration, which can be reported by any RenderObject 

BottomAreaAvoider isn't exactly something you might find in 'keyboard_avoider'- but it seems close enough, and rather than post a new lib, maybe this can be the library for avoidy functionality in general. 

todo: could add a unit test for findFocusedObject. 